### PR TITLE
Sanitize injected HTML for embedded pages

### DIFF
--- a/public/embed.html
+++ b/public/embed.html
@@ -15,7 +15,13 @@
       function safeInject(html) {
         // Never replace <head>, only <body> content
         if (typeof html !== "string" || /<head[\s>]/i.test(html)) return false;
-        document.body.innerHTML = html;
+
+        // Strip out any <script> tags to avoid executing arbitrary code
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(html, "text/html");
+        const scripts = doc.querySelectorAll("script");
+        scripts.forEach((s) => s.remove());
+        document.body.innerHTML = doc.body.innerHTML;
         return true;
       }
       

--- a/public/resume.html
+++ b/public/resume.html
@@ -15,7 +15,13 @@
       ];
       function safeInject(html) {
         if (typeof html !== "string" || /<head[\s>]/i.test(html)) return false;
-        document.body.innerHTML = html;
+
+        // Strip out any <script> tags to avoid executing arbitrary code
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(html, "text/html");
+        const scripts = doc.querySelectorAll("script");
+        scripts.forEach((s) => s.remove());
+        document.body.innerHTML = doc.body.innerHTML;
         return true;
       }
       window.addEventListener("message", (event) => {


### PR DESCRIPTION
## Summary
- Strip `<script>` tags from HTML injected into Wix iframe components to prevent unintended script execution.
- Apply sanitization to both `embed.html` and `resume.html` loaders.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run html:lint`


------
https://chatgpt.com/codex/tasks/task_e_689015185e3883238b284060f9ecae8b

## Summary by Sourcery

Sanitize HTML injected into Wix iframe components by stripping <script> tags in both embed.html and resume.html loaders to prevent unintended script execution

Enhancements:
- Add sanitization to strip <script> tags from injected HTML in public/embed.html
- Apply the same sanitization to public/resume.html loader

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security when injecting HTML content by automatically removing any embedded scripts, reducing the risk of script injection vulnerabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->