### PR TITLE
fix: avoid dev browser error

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 This static site implements a hybrid architecture that supports both standalone HTML pages and Wix-Velo iframe integration through postMessage communication.
 
+## Local Development
+
+Run `npm run dev` to preview the site at `http://localhost:3000`. The script opens your default browser when possible. On Linux systems without `xdg-open`, the server starts without launching a browser, so open the URL manually.
+
 ## File Structure
 
 ### Static HTML Pages

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "macrosight-site",
   "version": "2.0.0",
   "scripts": {
-    "dev": "vite preview --port 3000 --open",
+    "dev": "node scripts/dev.js",
     "build": "echo \"✅ Static site – no build needed\"",
     "preview": "vite preview",
     "lint": "eslint src/**/*.js || echo \"✅ No files to lint\"",

--- a/scripts/dev.js
+++ b/scripts/dev.js
@@ -1,0 +1,13 @@
+const { spawn, spawnSync } = require('child_process');
+
+// Determine whether to open the browser. On Linux this requires xdg-open.
+const hasXdgOpen = process.platform !== 'linux' || spawnSync('command', ['-v', 'xdg-open']).status === 0;
+
+const args = ['preview', '--port', '3000'];
+if (hasXdgOpen) {
+  args.push('--open');
+}
+
+const vite = spawn('vite', args, { stdio: 'inherit', shell: true });
+vite.on('close', (code) => process.exit(code));
+


### PR DESCRIPTION
## Summary
- only launch preview browser if xdg-open is available
- explain dev server browser behavior in README

## Testing
- `npm run lint` *(fails: $w is not defined)*
- `npm test` *(fails: Cannot find module '/workspace/MacroSight.net-v2/your-test-runner')*
- `npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_689034633cec8323898a3608cd438d17