### PR TITLE
Restrict backend permissions to authenticated users

### DIFF
--- a/src/backend/permissions.json
+++ b/src/backend/permissions.json
@@ -9,7 +9,7 @@
           "invoke": true
         },
         "anonymous": {
-          "invoke": true
+          "invoke": false
         }
       }
     }


### PR DESCRIPTION
## Summary
- disallow anonymous invocation of backend web methods to enforce authentication

## Testing
- `npm test` *(fails: Cannot find module 'your-test-runner')*
- `npm run lint` *(fails: '$w' is not defined in `wix-velo-integration.js`)*
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_6890346b54e08323b9a11cf538707e48