### PR TITLE
feat: add meta descriptions to public pages

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="description" content="Sorry, this MacroSight page couldn't be found.">
     <title>Page Not Found – MacroSight</title>
     <link rel="stylesheet" href="/styles.css">
   </head>

--- a/public/about.html
+++ b/public/about.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="description" content="Learn about MacroSight's strategic technology leadership and consulting services.">
     <title>About – MacroSight</title>
     <link rel="stylesheet" href="/styles.css">
   </head>

--- a/public/contact.html
+++ b/public/contact.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="description" content="Contact MacroSight to explore scalable technology solutions for your business.">
     <title>Contact – MacroSight</title>
     <link rel="stylesheet" href="/styles.css">
   </head>

--- a/public/embed.html
+++ b/public/embed.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="description" content="Secure page used to embed MacroSight content on external sites.">
     <title>MacroSight Embed</title>
     <link rel="stylesheet" href="/styles.css">
     <script>

--- a/public/experience.html
+++ b/public/experience.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="description" content="Explore MacroSight's track record in scalable systems and engineering leadership.">
     <title>Experience – MacroSight</title>
     <link rel="stylesheet" href="/styles.css">
   </head>

--- a/public/home.html
+++ b/public/home.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="description" content="MacroSight provides strategic technology leadership focused on scalable systems and business growth.">
     <title>MacroSight – Home</title>
     <link rel="stylesheet" href="/styles.css">
   </head>

--- a/public/invest.html
+++ b/public/invest.html
@@ -6,6 +6,7 @@
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="description" content="Embedded page that loads MacroSight's invest section for partners.">
     <title>Invest – MacroSight</title>
     <link rel="stylesheet" href="/styles.css">
     <script>

--- a/public/projects.html
+++ b/public/projects.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="description" content="Featured projects showcasing MacroSight's scalable architecture and cost-saving solutions.">
     <title>Projects – MacroSight</title>
     <link rel="stylesheet" href="/styles.css">
   </head>

--- a/public/resume.html
+++ b/public/resume.html
@@ -5,6 +5,7 @@
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="description" content="Embedded résumé highlighting MacroSight's professional background and qualifications.">
     <title>Résumé – MacroSight</title>
     <link rel="stylesheet" href="/styles.css">
     <script>


### PR DESCRIPTION
## Summary
- add meta description tags to all public HTML pages for better SEO

## Testing
- `npm run html:lint`
- `npm test` *(fails: Cannot find module '/workspace/MacroSight.net-v2/your-test-runner')*
- `curl -s http://localhost:8000/home.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6890346bac00832384d28c56f7208fb8