### PR TITLE
feat: load Inter font from Google Fonts

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap');
+
 *,
 *::before,
 *::after {


### PR DESCRIPTION
## Summary
- import Inter font via Google Fonts in global stylesheet

## Testing
- `npm test` (fails: Cannot find module 'your-test-runner')
- `npm run lint` (fails: `$w` is not defined errors)
- `npm run html:lint`


------
https://chatgpt.com/codex/tasks/task_e_6890346be9348323a252dbe07e0c1c9e