### PR TITLE
chore: add wix global to eslint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,5 +8,8 @@
     "ecmaVersion": "latest",
     "sourceType": "module"
   },
+  "globals": {
+    "$w": "readonly"
+  },
   "rules": {}
 }


### PR DESCRIPTION
## Summary
- declare Wix's `$w` as a read-only global for linting

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot find module 'your-test-runner')*
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_68903b04c6f08323bc39f3d7cb8ea38d