### PR TITLE
Ensure global styling injected and run tests in CI

### DIFF
--- a/.github/workflows/deploy-ci.yml
+++ b/.github/workflows/deploy-ci.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      - name: Run tests
+        run: npm test
+
       - name: Lint source code
         run: npx eslint src/pages/ src/public/ --fix
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "preview": "vite preview",
     "lint": "eslint src/**/*.js || echo \"✅ No files to lint\"",
     "format": "prettier --write public/**/*.html || echo \"✅ Nothing to format\"",
-    "test": "node your-test-runner",
+    "test": "node tests/globalStyles.test.mjs",
     "html:lint": "htmlhint \"public/*.html\"",
     "html:format": "prettier --write \"public/*.html\"",
     "ci": "npm run lint && npm run format && npm run build"

--- a/public/404.html
+++ b/public/404.html
@@ -38,5 +38,9 @@
         <p>&copy; 2025 MacroSight. All rights reserved.</p>
       </div>
     </footer>
+    <script type="module">
+      import { injectGlobalStyles } from "/globalStyles.js";
+      window.addEventListener("DOMContentLoaded", injectGlobalStyles);
+    </script>
   </body>
 </html>

--- a/public/about.html
+++ b/public/about.html
@@ -37,5 +37,9 @@
         <p>&copy; 2025 MacroSight. All rights reserved.</p>
       </div>
     </footer>
+    <script type="module">
+      import { injectGlobalStyles } from "/globalStyles.js";
+      window.addEventListener("DOMContentLoaded", injectGlobalStyles);
+    </script>
   </body>
 </html>

--- a/public/contact.html
+++ b/public/contact.html
@@ -38,5 +38,9 @@
         <p>&copy; 2025 MacroSight. All rights reserved.</p>
       </div>
     </footer>
+    <script type="module">
+      import { injectGlobalStyles } from "/globalStyles.js";
+      window.addEventListener("DOMContentLoaded", injectGlobalStyles);
+    </script>
   </body>
 </html>

--- a/public/experience.html
+++ b/public/experience.html
@@ -43,5 +43,9 @@
         <p>&copy; 2025 MacroSight. All rights reserved.</p>
       </div>
     </footer>
+    <script type="module">
+      import { injectGlobalStyles } from "/globalStyles.js";
+      window.addEventListener("DOMContentLoaded", injectGlobalStyles);
+    </script>
   </body>
 </html>

--- a/public/home.html
+++ b/public/home.html
@@ -39,5 +39,9 @@
         <p>&copy; 2025 MacroSight. All rights reserved.</p>
       </div>
     </footer>
+    <script type="module">
+      import { injectGlobalStyles } from "/globalStyles.js";
+      window.addEventListener("DOMContentLoaded", injectGlobalStyles);
+    </script>
   </body>
 </html>

--- a/public/projects.html
+++ b/public/projects.html
@@ -43,5 +43,9 @@
         <p>&copy; 2025 MacroSight. All rights reserved.</p>
       </div>
     </footer>
+    <script type="module">
+      import { injectGlobalStyles } from "/globalStyles.js";
+      window.addEventListener("DOMContentLoaded", injectGlobalStyles);
+    </script>
   </body>
 </html>

--- a/tests/globalStyles.test.mjs
+++ b/tests/globalStyles.test.mjs
@@ -1,0 +1,25 @@
+import assert from 'node:assert';
+import { injectGlobalStyles } from '../public/globalStyles.js';
+
+// Minimal mock of the DOM APIs used in injectGlobalStyles
+global.document = {
+  elements: {},
+  getElementById(id) {
+    return this.elements[id] || null;
+  },
+  createElement(tag) {
+    return { tagName: tag, id: '', textContent: '' };
+  },
+  head: {
+    appendChild(el) {
+      document.elements[el.id] = el;
+    }
+  }
+};
+
+injectGlobalStyles();
+
+assert.ok(document.getElementById('macrosight-global-styles'), 'global styles were not injected');
+
+console.log('✅ globalStyles test passed');
+


### PR DESCRIPTION
## Summary
- inject `globalStyles.js` on DOMContentLoaded across HTML pages
- add minimal test verifying global style injection and hook it into CI workflow

## Testing
- `npm run lint`
- `npm run html:lint`
- `npm test`
- custom html check

------
https://chatgpt.com/codex/tasks/task_e_6890418add0083239c4b6a6836fa2d8f