### PR TITLE
chore: allow lint pipeline to skip empty dirs

### DIFF
--- a/.github/workflows/deploy-ci.yml
+++ b/.github/workflows/deploy-ci.yml
@@ -26,10 +26,10 @@ jobs:
         run: npm test
 
       - name: Lint source code
-        run: npx eslint src/pages/ src/public/ --fix
+        run: npx eslint src/pages/ src/public/ --fix --no-error-on-unmatched-pattern
 
       - name: Format source code
-        run: npx prettier --write src/pages/ src/public/
+        run: npx prettier --write src/pages/ src/public/ --no-error-on-unmatched-pattern
 
       - name: HTMLHint checks
         run: npx htmlhint "public/*.html"


### PR DESCRIPTION
## Summary
- don't fail CI linting when src subdirectories lack files

## Testing
- `npm test`
- `npx eslint src/pages/ src/public/ --fix --no-error-on-unmatched-pattern`
- `npx prettier --write src/pages/ src/public/ --no-error-on-unmatched-pattern`

------
https://chatgpt.com/codex/tasks/task_e_68904647ad748323a563dbbdd3bc4aff

## Summary by Sourcery

Allow CI linting pipeline to skip empty directories without failing by adding the appropriate flags to ESLint and Prettier commands

CI:
- Add --no-error-on-unmatched-pattern flag to the ESLint step in the CI workflow
- Add --no-error-on-unmatched-pattern flag to the Prettier step in the CI workflow