### PR TITLE
refactor: consolidate wix velo init

### DIFF
--- a/src/backend/wix-velo-integration.js
+++ b/src/backend/wix-velo-integration.js
@@ -3,60 +3,55 @@
 
 import { fetch } from "wix-fetch";
 
-$w.onReady(function () {
-  // Find your HTML component iframe
-  const htmlComponent = $w("#htmlComponent1"); // Replace with your actual component ID
-
-  // Function to load content into iframe
+function initializeDynamicLoading(htmlComponent) {
   async function loadPageContent(pageName) {
     try {
-      // Fetch the HTML content from your Netlify site
       const response = await fetch(
         `https://www.macrosight.net/${pageName}.html`,
       );
       const htmlContent = await response.text();
 
-      // Post the content to the iframe
       const iframe = htmlComponent.contentWindow;
       iframe.postMessage(htmlContent, "https://www.macrosight.net");
     } catch (error) {
       console.error("Failed to load content:", error);
-      // Fallback - load the embed page directly
       htmlComponent.src = `https://www.macrosight.net/embed.html`;
     }
   }
 
-  // Load home page by default
   loadPageContent("home");
 
-  // Example: Load different pages based on user interaction
   $w("#homeButton").onClick(() => loadPageContent("home"));
   $w("#aboutButton").onClick(() => loadPageContent("about"));
   $w("#projectsButton").onClick(() => loadPageContent("projects"));
   $w("#experienceButton").onClick(() => loadPageContent("experience"));
   $w("#contactButton").onClick(() => loadPageContent("contact"));
 
-  // For resume and invest pages, they already have postMessage handling
   $w("#resumeButton").onClick(() => loadPageContent("resume"));
   $w("#investButton").onClick(() => loadPageContent("invest"));
-});
+}
 
-// Alternative approach: If you want to use the embed.html for everything
-$w.onReady(function () {
-  const htmlComponent = $w("#htmlComponent1");
-
-  // Set the iframe source to embed.html
+function initializeEmbed(htmlComponent) {
   htmlComponent.src = "https://www.macrosight.net/embed.html";
 
-  // Then post content to it
   setTimeout(() => {
     const iframe = htmlComponent.contentWindow;
 
-    // You can fetch and post any page content
     fetch("https://www.macrosight.net/home.html")
       .then((response) => response.text())
       .then((html) => {
         iframe.postMessage(html, "https://www.macrosight.net");
       });
-  }, 1000); // Give iframe time to load
+  }, 1000);
+}
+
+$w.onReady(function () {
+  const htmlComponent = $w("#htmlComponent1");
+  const useEmbed = false; // Feature flag for alternative initialization
+
+  if (useEmbed) {
+    initializeEmbed(htmlComponent);
+  } else {
+    initializeDynamicLoading(htmlComponent);
+  }
 });


### PR DESCRIPTION
## Summary
- merge duplicate Wix onReady blocks into a single entry point
- keep alternative embed approach behind `useEmbed` feature flag

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689058cca4748323b245a2198fa794e3