### PR TITLE
Use DOMParser to sanitize Invest page injection

### DIFF
--- a/public/invest.html
+++ b/public/invest.html
@@ -20,7 +20,13 @@
       ];
       function safeInject(html) {
         if (typeof html !== "string" || /<head[\s>]/i.test(html)) return false;
-        document.body.innerHTML = html;
+
+        // Strip out any <script> tags to avoid executing arbitrary code
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(html, "text/html");
+        const scripts = doc.querySelectorAll("script");
+        scripts.forEach((s) => s.remove());
+        document.body.innerHTML = doc.body.innerHTML;
         return true;
       }
       window.addEventListener(


### PR DESCRIPTION
## Summary
- harden `safeInject` in Invest iframe to parse HTML via `DOMParser`
- remove any `<script>` elements before injecting content

## Testing
- `npm run lint`
- `npm run html:lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689058ce670c83238ffb0681fced8d70

## Summary by Sourcery

Harden the safeInject function in the Invest page by using DOMParser to sanitize HTML and remove script elements before injection.

Enhancements:
- Switch safeInject to parse incoming HTML with DOMParser to safely handle markup
- Strip out any <script> tags from the parsed content before setting innerHTML