### PR TITLE
Add iframe sanitization tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "preview": "vite preview",
     "lint": "eslint src/**/*.js || echo \"✅ No files to lint\"",
     "format": "prettier --write public/**/*.html || echo \"✅ Nothing to format\"",
-    "test": "node tests/globalStyles.test.mjs",
+    "test": "node tests/globalStyles.test.mjs && node tests/iframePages.test.mjs",
     "html:lint": "htmlhint \"public/*.html\"",
     "html:format": "prettier --write \"public/*.html\"",
     "ci": "npm run lint && npm run format && npm run build"

--- a/public/invest.html
+++ b/public/invest.html
@@ -20,7 +20,12 @@
       ];
       function safeInject(html) {
         if (typeof html !== "string" || /<head[\s>]/i.test(html)) return false;
-        document.body.innerHTML = html;
+        // Strip out any <script> tags to avoid executing arbitrary code
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(html, "text/html");
+        const scripts = doc.querySelectorAll("script");
+        scripts.forEach((s) => s.remove());
+        document.body.innerHTML = doc.body.innerHTML;
         return true;
       }
       window.addEventListener(

--- a/tests/iframePages.test.mjs
+++ b/tests/iframePages.test.mjs
@@ -1,0 +1,81 @@
+import assert from "node:assert";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import vm from "node:vm";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const pages = ["embed.html", "resume.html", "invest.html"];
+const payload = "<div>Test Content</div><script>console.log('bad')</script>";
+
+for (const page of pages) {
+  const html = readFileSync(path.join(__dirname, "..", "public", page), "utf8");
+  const scriptMatch = html.match(/<script>([\s\S]*?)<\/script>/);
+  if (!scriptMatch) throw new Error(`No script tag found in ${page}`);
+  const scriptContent = scriptMatch[1];
+
+  const document = {
+    body: { innerHTML: '<div class="loader">Loading…</div>' },
+    querySelector(sel) {
+      if (sel === ".loader" && this.body.innerHTML.includes('class="loader"')) {
+        return { style: { display: "" } };
+      }
+      return null;
+    },
+  };
+
+  class DOMParser {
+    parseFromString(html) {
+      const doc = {
+        body: { innerHTML: html },
+        querySelectorAll(selector) {
+          if (selector !== "script") return [];
+          const scripts = [];
+          const regex = /<script[\s\S]*?<\/script>/gi;
+          let match;
+          while ((match = regex.exec(doc.body.innerHTML))) {
+            const scriptText = match[0];
+            scripts.push({
+              remove() {
+                doc.body.innerHTML = doc.body.innerHTML.replace(scriptText, "");
+              },
+            });
+          }
+          return scripts;
+        },
+      };
+      return doc;
+    }
+  }
+
+  const events = {};
+  const window = {
+    addEventListener(type, handler) {
+      events[type] = handler;
+    },
+    dispatchEvent(event) {
+      const handler = events[event.type];
+      if (handler) handler(event);
+    },
+    top: {},
+    self: {},
+  };
+
+  vm.runInNewContext(scriptContent, { window, document, DOMParser });
+
+  window.dispatchEvent({
+    type: "message",
+    data: payload,
+    origin: "https://www.macrosight.net",
+  });
+
+  assert.ok(
+    !document.body.innerHTML.includes("<script"),
+    `${page}: script tag was not removed`,
+  );
+  assert.ok(
+    !document.body.innerHTML.includes("loader"),
+    `${page}: loader was not hidden`,
+  );
+  console.log(`✅ ${page} script sanitized and loader hidden`);
+}


### PR DESCRIPTION
## Summary
- harden invest embed by stripping `<script>` tags before injection
- add tests that load each iframe page, post HTML with scripts, and ensure sanitization and loader removal
- run new iframe tests via `npm test`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689058d0b840832393adcdeac56352e7

## Summary by Sourcery

Harden iframe content injection by stripping out script tags before injecting HTML and add end-to-end tests to verify sanitization and loader removal.

New Features:
- Add iframePages.test.mjs to test sanitization and loader removal in iframe pages

Enhancements:
- Strip <script> tags in safeInject to harden HTML injection
- Update npm test script to include iframe pages sanitization tests

Tests:
- Add tests that load embed.html, resume.html, and invest.html, post HTML with scripts, and assert script removal and loader hiding

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security in embedded pages by ensuring injected HTML content is sanitized and script tags are removed.

* **Tests**
  * Added new tests to verify that embedded pages properly sanitize injected HTML and hide the loader element.
  * Updated test scripts to include these new security checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->