### PR TITLE
refactor: unify wix init

### DIFF
--- a/src/backend/wix-velo-integration.js
+++ b/src/backend/wix-velo-integration.js
@@ -3,6 +3,9 @@
 
 import { fetch } from "wix-fetch";
 
+// Feature flag to switch between embed mode and dynamic loading
+const USE_EMBED = false;
+
 function initializeDynamicLoading(htmlComponent) {
   async function loadPageContent(pageName) {
     try {
@@ -45,13 +48,15 @@ function initializeEmbed(htmlComponent) {
   }, 1000);
 }
 
-$w.onReady(function () {
-  const htmlComponent = $w("#htmlComponent1");
-  const useEmbed = false; // Feature flag for alternative initialization
-
-  if (useEmbed) {
+function initialize(htmlComponent) {
+  if (USE_EMBED) {
     initializeEmbed(htmlComponent);
   } else {
     initializeDynamicLoading(htmlComponent);
   }
+}
+
+$w.onReady(() => {
+  const htmlComponent = $w("#htmlComponent1");
+  initialize(htmlComponent);
 });


### PR DESCRIPTION
## Summary
- consolidate Wix Velo initialisation into a single `$w.onReady` block
- gate embed behaviour behind `USE_EMBED` feature flag

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68905b8c5eb88323befb2a79b798fa9c

## Summary by Sourcery

Unify Wix Velo initialization by consolidating onReady logic into a single entrypoint and gate embed behavior behind a feature flag

Enhancements:
- Consolidate Wix initialization into a single initialize function invoked in $w.onReady
- Introduce a USE_EMBED feature flag to toggle between embed mode and dynamic loading