### PR TITLE
fix: remove stray bracket in global styles

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -219,7 +219,6 @@ header nav {
   );
   color: #ffffff;
 }
-}
 
 /* Skeleton loader for Wix HTML injection */
 .loader {


### PR DESCRIPTION
## Summary
- fix CSS typo that prevented styles after button focus from loading

## Testing
- `npm test`
- `npm run lint`
- `npm run html:lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_689062a0f1048323801829a2255f5739

## Summary by Sourcery

Bug Fixes:
- Remove extraneous '}' in public/styles.css that prevented later styles from loading