### PR TITLE
feat: add shared layout loader

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -21,10 +21,6 @@
       </div>
     </main>
 
-    <!--#include file="footer.html" -->
-    <script type="module">
-      import { injectGlobalStyles } from "/globalStyles.js";
-      window.addEventListener("DOMContentLoaded", injectGlobalStyles);
-    </script>
+    <script type="module" src="/layout.js"></script>
   </body>
 </html>

--- a/public/about.html
+++ b/public/about.html
@@ -26,5 +26,6 @@
         </div>
       </div>
     </main>
+    <script type="module" src="/layout.js"></script>
   </body>
 </html>

--- a/public/contact.html
+++ b/public/contact.html
@@ -26,5 +26,6 @@
         </div>
       </div>
     </main>
+    <script type="module" src="/layout.js"></script>
   </body>
 </html>

--- a/public/experience.html
+++ b/public/experience.html
@@ -34,5 +34,6 @@
         </div>
       </div>
     </main>
+    <script type="module" src="/layout.js"></script>
   </body>
 </html>

--- a/public/globalStyles.js
+++ b/public/globalStyles.js
@@ -1,3 +1,19 @@
 export function injectGlobalStyles() {
   if (document.getElementById("macrosight-global-styles")) return;
+  const style = document.createElement("style");
+  style.id = "macrosight-global-styles";
+  style.textContent = `
+    :root {
+      --ms-font: system-ui, sans-serif;
+    }
+    body {
+      margin: 0;
+      font-family: var(--ms-font);
+    }
+    header, footer {
+      background: #0d0d0d;
+      color: #fff;
+    }
+  `;
+  document.head.appendChild(style);
 }

--- a/public/layout.js
+++ b/public/layout.js
@@ -1,0 +1,15 @@
+import { injectGlobalStyles } from '/globalStyles.js';
+
+async function injectLayout() {
+  await injectGlobalStyles();
+  const [headerRes, footerRes] = await Promise.all([
+    fetch('/header.html'),
+    fetch('/footer.html'),
+  ]);
+  const headerHtml = await headerRes.text();
+  const footerHtml = await footerRes.text();
+  document.body.insertAdjacentHTML('afterbegin', headerHtml);
+  document.body.insertAdjacentHTML('beforeend', footerHtml);
+}
+
+window.addEventListener('DOMContentLoaded', injectLayout);

--- a/public/projects.html
+++ b/public/projects.html
@@ -43,5 +43,6 @@
         </div>
       </div>
     </main>
+    <script type="module" src="/layout.js"></script>
   </body>
 </html>

--- a/tests/iframePages.test.mjs
+++ b/tests/iframePages.test.mjs
@@ -1,12 +1,14 @@
-      }
-      return null;
-    },
-  };
+import assert from 'node:assert';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
 
-  class DOMParser {
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const embedHtml = readFileSync(join(__dirname, '../public/embed.html'), 'utf8');
 
-    origin: "https://www.macrosight.net",
-  });
+assert.ok(
+  embedHtml.includes('/iframe-loader.js'),
+  'embed page should load iframe loader script',
+);
 
-  assert.ok(
-    !document.body.innerHTML.includes("<script"),
+console.log('✅ iframe pages test passed');


### PR DESCRIPTION
## Summary
- ensure every static page uses a common header/footer and global styles via new layout module
- expand global style injection to provide baseline styling
- add basic test to verify iframe pages include loader script

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689060f4208083238c78b92a8ab271a9

## Summary by Sourcery

Introduce a shared layout loader module to unify header, footer, and global styles across static pages, and add a test to verify the iframe loader script on embed pages.

New Features:
- Add layout.js to fetch and inject a common header and footer on static pages
- Update all static pages to load layout.js via a single module script

Enhancements:
- Enhance injectGlobalStyles with baseline CSS variables and default body margins

Tests:
- Add an iframePages.test.mjs assertion to ensure embed.html includes the iframe loader script