### PR TITLE
Add stylesheet and script tags to header

### DIFF
--- a/public/header.html
+++ b/public/header.html
@@ -12,4 +12,10 @@
       <a href="invest.html">Invest</a>
     </nav>
   </div>
+  <link rel="stylesheet" href="./styles.css" />
+  <script>
+    window.addEventListener("DOMContentLoaded", () => {
+      // Your script here
+    });
+  </script>
 </header>


### PR DESCRIPTION
## Summary
- add missing stylesheet link to header
- include DOMContentLoaded script block

## Testing
- `npm test`
- `npm run lint`
- `npm run html:lint`


------
https://chatgpt.com/codex/tasks/task_e_6890661ff6348323837c8ebf238262c5

## Summary by Sourcery

Add a stylesheet reference and a DOMContentLoaded event listener script to the page header

Enhancements:
- Add stylesheet link to header template
- Insert DOMContentLoaded script block in header