### PR TITLE
refactor: rely on shared header include

### DIFF
--- a/public/home.html
+++ b/public/home.html
@@ -20,27 +20,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
   </head>
   <body class="bg-gray-900 text-gray-100 font-sans">
-    <!-- htmlhint doctype-first:false -->
-<header class="site-header">
-  <div class="section header-content">
-    <a class="brand" href="/"><span>MACROsite</span></a>
-    <button id="menu-btn" class="menu-btn" aria-expanded="false" aria-label="Toggle navigation">
-      <span class="sr-only">Menu</span>
-    </button>
-    <nav id="menu" class="hidden" aria-label="Primary">
-      <a href="/home">Home</a>
-      <a href="/projects">Projects</a>
-      <a href="/experience">Experience</a>
-      <a href="/about">About</a>
-      <a href="/contact">Contact</a>
-      <a href="/resume">Resume</a>
-    </nav>
-  </div>
-</header>
-<script>
-  window.addEventListener('DOMContentLoaded', () => {});
-</script>
-<!-- AI will replace this with header.html during build -->
+    <!--#HEADER#--><!-- AI will replace this with header.html during build -->
 
     <!-- Progressive enhancement: keep runtime include for cache-busted updates -->
     <div id="header-placeholder" hidden></div>


### PR DESCRIPTION
## Summary
- remove hardcoded header from `home.html` so build step injects the shared navigation consistently

## Testing
- `npm run build`
- `echo "🔎 Checking HTML for <link> and <script> tags..."; for f in $(find public -type f -name '*.html'); do if ! grep -q '<link rel="stylesheet"' "$f" || ! grep -q 'window.addEventListener' "$f"; then echo "❌ $f missing <link> or <script"; exit 1; fi; done; echo "✅ HTML structure passed.";`
- `npm test`
- `npm run check:links` *(fails: 403 Forbidden - GET https://registry.npmjs.org/linkinator)*

------
https://chatgpt.com/codex/tasks/task_e_689adedb710c83239b497702ee5828d9